### PR TITLE
Feat: Trigger block stream immediately on height update in ChainStream.ts

### DIFF
--- a/src/ChainStream.ts
+++ b/src/ChainStream.ts
@@ -18,11 +18,13 @@ import {
   catchError,
   concatMap,
   expand,
+  filter,
   interval,
   of,
   range,
   retry,
   switchMap,
+  take,
   tap,
   timer
 } from "rxjs";
@@ -114,10 +116,12 @@ export class ChainStream {
         }
 
         if (currentBlock >= this.chainInfo.value.height) {
-          return of([]).pipe(
-            tap(() => this.logger.log(`No new blocks, retrying after ${config.gracePeriodMs} ms...`)),
-            delay(config.gracePeriodMs),
-            switchMap(() => of([]))
+          // Listen for chainInfo updates and emit only when new height is greater than currentBlock
+          return this.chainInfo.pipe(
+            tap(newInfo => this.logger.log(`No new blocks, current height ${this.chainInfo.value.height}, waiting for new blocks above ${currentBlock}. New info height: ${newInfo.height}`)),
+            filter(newInfo => newInfo.height > currentBlock),
+            take(1), // Take the first emission that satisfies the condition
+            switchMap(() => of([])) // Continue with an empty emission to trigger the next expand cycle
           );
         }
 

--- a/src/ChainStream.ts
+++ b/src/ChainStream.ts
@@ -116,12 +116,10 @@ export class ChainStream {
         }
 
         if (currentBlock >= this.chainInfo.value.height) {
-          // Listen for chainInfo updates and emit only when new height is greater than currentBlock
           return this.chainInfo.pipe(
-            tap(newInfo => this.logger.log(`No new blocks, current height ${this.chainInfo.value.height}, waiting for new blocks above ${currentBlock}. New info height: ${newInfo.height}`)),
-            filter(newInfo => newInfo.height > currentBlock),
-            take(1), // Take the first emission that satisfies the condition
-            switchMap(() => of([])) // Continue with an empty emission to trigger the next expand cycle
+            filter((newInfo) => newInfo.height > currentBlock),
+            take(1),
+            switchMap(() => of([]))
           );
         }
 


### PR DESCRIPTION
The `fromBlock` method in `ChainStream.ts` was modified to react immediately to chain height updates. Previously, it would wait for a grace period before checking for new blocks.

The `expand` operator in `fromBlock` now listens to changes in `this.chainInfo`. When the current block height is reached, instead of a fixed delay, it waits for `this.chainInfo` to emit a new height greater than the current block.

This commit only includes changes to `src/ChainStream.ts`.